### PR TITLE
Customizable icon and selected rect alpha

### DIFF
--- a/rangeseekbar-sample/src/main/java/org/florescu/android/rangeseekbar/sample/DemoActivity.java
+++ b/rangeseekbar-sample/src/main/java/org/florescu/android/rangeseekbar/sample/DemoActivity.java
@@ -18,7 +18,10 @@ limitations under the License.
 package org.florescu.android.rangeseekbar.sample;
 
 import android.app.Activity;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.widget.LinearLayout;
 
 import org.florescu.android.rangeseekbar.RangeSeekBar;
@@ -47,5 +50,10 @@ public class DemoActivity extends Activity {
         // Seek bar for which we will set text color in code
         RangeSeekBar rangeSeekBarTextColorWithCode = (RangeSeekBar) findViewById(R.id.rangeSeekBarTextColorWithCode);
         rangeSeekBarTextColorWithCode.setTextAboveThumbsColorResource(android.R.color.holo_blue_bright);
+
+        // Seek bar for which we will set icon on bar and its color in code
+        RangeSeekBar rangeSeekBarIconOnBarWithCode = (RangeSeekBar) findViewById(R.id.rangeSeekBarIconOnBarWithCode);
+        Drawable iconOnBarDrawable = ContextCompat.getDrawable(this, android.R.drawable.ic_lock_idle_alarm);
+        rangeSeekBarIconOnBarWithCode.setIconOnBar(iconOnBarDrawable, Color.WHITE);
     }
 }

--- a/rangeseekbar-sample/src/main/res/layout/main.xml
+++ b/rangeseekbar-sample/src/main/res/layout/main.xml
@@ -185,6 +185,61 @@
             rsb:thumbShadowYOffset="2dp"
             />
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="8dp"
+            android:text="Transparent range seek bar from xml with 2 different thumb handles and icon on bar"
+            />
+
+        <org.florescu.android.rangeseekbar.RangeSeekBar
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            rsb:selectedRectColor="@android:color/holo_red_light"
+            rsb:selectedRectAlpha="50"
+            rsb:thumbNormal="@drawable/left_trim_handle"
+            rsb:thumbDisabled="@drawable/left_trim_handle"
+            rsb:thumbPressed="@drawable/left_trim_handle"
+            rsb:hasDifferentRightThumb="true"
+            rsb:rightThumbNormal="@drawable/right_trim_handle"
+            rsb:rightThumbDisabled="@drawable/right_trim_handle"
+            rsb:rightThumbPressed="@drawable/right_trim_handle"
+            rsb:iconOnBar="@mipmap/ic_launcher"
+            rsb:iconOnBarColor="@android:color/holo_purple"
+            rsb:barHeight="2dp"
+            rsb:showLabels="false"
+            rsb:valuesAboveThumbs="false"
+            rsb:showSelectedRect="true"
+            rsb:allowSelectedRectDrag="false"
+            />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="8dp"
+            android:text="Draggable range seek bar from xml with 2 different thumb handles and icon on bar"
+            />
+
+        <org.florescu.android.rangeseekbar.RangeSeekBar
+            android:id="@+id/rangeSeekBarIconOnBarWithCode"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            rsb:activeColor="@android:color/holo_orange_dark"
+            rsb:selectedRectColor="@android:color/holo_blue_light"
+            rsb:selectedRectAlpha="255"
+            rsb:thumbNormal="@drawable/left_trim_handle"
+            rsb:thumbDisabled="@drawable/left_trim_handle"
+            rsb:thumbPressed="@drawable/left_trim_handle"
+            rsb:hasDifferentRightThumb="true"
+            rsb:rightThumbNormal="@drawable/right_trim_handle"
+            rsb:rightThumbDisabled="@drawable/right_trim_handle"
+            rsb:rightThumbPressed="@drawable/right_trim_handle"
+            rsb:barHeight="2dp"
+            rsb:showLabels="false"
+            rsb:valuesAboveThumbs="false"
+            rsb:showSelectedRect="true"
+            rsb:allowSelectedRectDrag="true"
+            />
 
     </LinearLayout>
 

--- a/rangeseekbar/src/main/res/values/attrs.xml
+++ b/rangeseekbar/src/main/res/values/attrs.xml
@@ -38,8 +38,9 @@
         <!-- the color of the text above thumbs -->
         <attr name="textAboveThumbsColor" format="color"/>
 
-        <!-- the color of the selected rect (if visible) -->
+        <!-- the color and opacity of the selected rect (if visible) -->
         <attr name="selectedRectColor" format="color"/>
+        <attr name="selectedRectAlpha" format="integer"/>
 
         <!-- the stroke color of the selected rect (if visible) -->
         <attr name="selectedRectStrokeColor" format="color"/>
@@ -70,6 +71,13 @@
 
         <!-- if the selected rect is visible we can also allow the user to drag it (i.e so the min and max handles move at the same time) -->
         <attr name="allowSelectedRectDrag" format="boolean"/>
+
+        <!-- set drawable for any icon that should be displayed to right of min value -->
+        <attr name="iconOnBar" format="reference"/>
+
+        <!-- the color of the icon on the bar -->
+        <attr name="iconOnBarColor" format="color"/>
+
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
RangeSeekBar has been modified to allow the following:
- Customization of selected rectangle’s alpha value
- Specification of an icon to draw to the right of the min value and what color to draw it in. This info can be specified in xml using the `selectedRectAlpha`, `iconOnBar`, and `iconOnBarColor` attributes. The icon and its color can also be specified programmatically using `setIconOnBar`.
  ![rangeseekbaralphaiconcustomize](https://cloud.githubusercontent.com/assets/15043814/15348148/f336ce04-1c7c-11e6-91e6-eb74f6c8b8c8.png)
