### PR TITLE
Selected Rect without Stroke, Show/Hide Thumbs, Selected Rect Color when control is disabled 

### DIFF
--- a/rangeseekbar-sample/src/main/java/org/florescu/android/rangeseekbar/sample/DemoActivity.java
+++ b/rangeseekbar-sample/src/main/java/org/florescu/android/rangeseekbar/sample/DemoActivity.java
@@ -27,6 +27,7 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
+import android.view.View;
 import android.widget.LinearLayout;
 
 import org.florescu.android.rangeseekbar.RangeSeekBar;
@@ -60,5 +61,11 @@ public class DemoActivity extends Activity {
         RangeSeekBar rangeSeekBarIconOnBarWithCode = (RangeSeekBar) findViewById(R.id.rangeSeekBarIconOnBarWithCode);
         Drawable iconOnBarDrawable = ContextCompat.getDrawable(this, android.R.drawable.ic_lock_idle_alarm);
         rangeSeekBarIconOnBarWithCode.setIconOnBar(iconOnBarDrawable, Color.WHITE);
+    }
+
+    public void toggleSeekBarEnabled(View v) {
+        RangeSeekBar rangeSeekBarNoThumbs = (RangeSeekBar) findViewById(R.id.rangeSeekBarNoThumbs);
+        rangeSeekBarNoThumbs.setEnabled(!rangeSeekBarNoThumbs.isEnabled());
+        rangeSeekBarNoThumbs.setShowThumbs(rangeSeekBarNoThumbs.isEnabled());
     }
 }

--- a/rangeseekbar-sample/src/main/res/layout/main.xml
+++ b/rangeseekbar-sample/src/main/res/layout/main.xml
@@ -241,6 +241,34 @@
             rsb:allowSelectedRectDrag="true"
             />
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="8dp"
+            android:text="Draggable range seek bar with selected rect that has no stroke"
+            />
+
+        <org.florescu.android.rangeseekbar.RangeSeekBar
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            rsb:activeColor="@android:color/holo_orange_dark"
+            rsb:selectedRectColor="@android:color/holo_blue_light"
+            rsb:selectedRectAlpha="255"
+            rsb:thumbNormal="@drawable/left_trim_handle"
+            rsb:thumbDisabled="@drawable/left_trim_handle"
+            rsb:thumbPressed="@drawable/left_trim_handle"
+            rsb:hasDifferentRightThumb="true"
+            rsb:rightThumbNormal="@drawable/right_trim_handle"
+            rsb:rightThumbDisabled="@drawable/right_trim_handle"
+            rsb:rightThumbPressed="@drawable/right_trim_handle"
+            rsb:barHeight="2dp"
+            rsb:showLabels="false"
+            rsb:valuesAboveThumbs="false"
+            rsb:showSelectedRect="true"
+            rsb:allowSelectedRectDrag="true"
+            rsb:showSelectedRectStroke="false"
+            />
+
     </LinearLayout>
 
 </ScrollView>

--- a/rangeseekbar-sample/src/main/res/layout/main.xml
+++ b/rangeseekbar-sample/src/main/res/layout/main.xml
@@ -269,6 +269,43 @@
             rsb:showSelectedRectStroke="false"
             />
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="8dp"
+            android:text="range seek bar with selected rect that has thumb handles hidden and rect color changed when you toggle the control enabled/disabled"
+            />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="toggleSeekBarEnabled"
+            android:text="Toggle Enabled"/>
+
+        <org.florescu.android.rangeseekbar.RangeSeekBar
+            android:id="@+id/rangeSeekBarNoThumbs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            rsb:activeColor="@android:color/holo_orange_dark"
+            rsb:selectedRectColor="@android:color/holo_blue_light"
+            rsb:selectedRectAlpha="200"
+            rsb:thumbNormal="@drawable/left_trim_handle"
+            rsb:thumbDisabled="@drawable/left_trim_handle"
+            rsb:thumbPressed="@drawable/left_trim_handle"
+            rsb:hasDifferentRightThumb="true"
+            rsb:rightThumbNormal="@drawable/right_trim_handle"
+            rsb:rightThumbDisabled="@drawable/right_trim_handle"
+            rsb:rightThumbPressed="@drawable/right_trim_handle"
+            rsb:barHeight="2dp"
+            rsb:showLabels="false"
+            rsb:valuesAboveThumbs="false"
+            rsb:showSelectedRect="true"
+            rsb:allowSelectedRectDrag="true"
+            rsb:showSelectedRectStroke="false"
+            rsb:selectedRectDisabledColor="@color/primary_material_light"
+            rsb:selectedRectDisabledAlpha="255"
+            />
+
     </LinearLayout>
 
 </ScrollView>

--- a/rangeseekbar/src/main/java/org/florescu/android/rangeseekbar/RangeSeekBar.java
+++ b/rangeseekbar/src/main/java/org/florescu/android/rangeseekbar/RangeSeekBar.java
@@ -23,6 +23,7 @@ Agile Sports Technologies, Inc. Modifications:
 - Allow right thumb handle image to be configured
 - Expose which handle was last touched in on change listener
 - Add configuration to display icon to left of left thumb
+- Allowing selected rectangle stroke to be switched on/off
 */
 
 package org.florescu.android.rangeseekbar;
@@ -101,6 +102,7 @@ public class RangeSeekBar<T extends Number> extends ImageView {
     private static final int ICON_ON_BAR_SIDE_IN_DP = 20;
 
     private static final int DEFAULT_SELECTED_RECT_ALPHA = 150;
+    private static final int SELECTED_RECT_STROKE_WIDTH_IN_DP = 4;
 
     private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
     private final Paint shadowPaint = new Paint();
@@ -144,6 +146,7 @@ public class RangeSeekBar<T extends Number> extends ImageView {
     private boolean mSingleThumb;
     private boolean mAlwaysActive;
     private boolean mShowSelectedBorder;
+    private boolean mShowSelectedRectStroke;
     private boolean mShowLabels;
     private boolean mShowTextAboveThumbs;
     private boolean mIsProgressBar;
@@ -155,6 +158,7 @@ public class RangeSeekBar<T extends Number> extends ImageView {
     private int mSelectedRectAlpha;
     private int mSelectedRectStrokeColor;
     private int mTextAboveThumbsColor;
+    private int mSelectedRectStrokeOffsetDp;
     private double mInBetweenDragMarker;
 
     private boolean mThumbShadow;
@@ -245,6 +249,8 @@ public class RangeSeekBar<T extends Number> extends ImageView {
                 mSelectedRectColor = a.getColor(R.styleable.RangeSeekBar_selectedRectColor, Color.parseColor("#4D4D4D"));
                 mSelectedRectAlpha = a.getInt(R.styleable.RangeSeekBar_selectedRectAlpha, DEFAULT_SELECTED_RECT_ALPHA);
                 mSelectedRectStrokeColor = a.getColor(R.styleable.RangeSeekBar_selectedRectStrokeColor, Color.WHITE);
+                mShowSelectedRectStroke = a.getBoolean(R.styleable.RangeSeekBar_showSelectedRectStroke, true);
+                mSelectedRectStrokeOffsetDp = mShowSelectedRectStroke ? SELECTED_RECT_STROKE_WIDTH_IN_DP/2 : 0;
                 mAllowSectedRectDrag = mShowSelectedBorder && a.getBoolean(R.styleable.RangeSeekBar_allowSelectedRectDrag, false);
 
                 mAlwaysActive = a.getBoolean(R.styleable.RangeSeekBar_alwaysActive, false);
@@ -344,12 +350,15 @@ public class RangeSeekBar<T extends Number> extends ImageView {
                 mTextOffset + mThumbHalfHeight + barHeight / 2);
 
         mBorderRect = new RectF();
-        mBorderRect.top = mTextOffset + PixelUtil.dpToPx(context, 2);
-        mBorderRect.bottom = (mTextOffset + (mThumbHalfHeight*2.0f)) - PixelUtil.dpToPx(context, 2);
+        mBorderRect.top = mTextOffset + PixelUtil.dpToPx(context, mSelectedRectStrokeOffsetDp);
+        mBorderRect.bottom = (mTextOffset + (mThumbHalfHeight*2.0f)) - PixelUtil.dpToPx(context, mSelectedRectStrokeOffsetDp);
 
         mBorderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
         mBorderPaint.setStyle(Paint.Style.FILL_AND_STROKE);
-        mBorderPaint.setStrokeWidth(PixelUtil.dpToPx(context, 4));
+
+        if (mShowSelectedRectStroke) {
+            mBorderPaint.setStrokeWidth(PixelUtil.dpToPx(context, SELECTED_RECT_STROKE_WIDTH_IN_DP));
+        }
 
         // make RangeSeekBar focusable. This solves focus handling issues in case EditText widgets are being used along with the RangeSeekBar within ScrollViews.
         setFocusable(true);
@@ -770,10 +779,12 @@ public class RangeSeekBar<T extends Number> extends ImageView {
             mBorderPaint.setAlpha(mSelectedRectAlpha);
             canvas.drawRect(mBorderRect, mBorderPaint);
 
-            mBorderPaint.setStyle(Paint.Style.STROKE);
-            mBorderPaint.setColor(mSelectedRectStrokeColor);
-            mBorderPaint.setAlpha(255);
-            canvas.drawRect(mBorderRect, mBorderPaint);
+            if (mShowSelectedRectStroke) {
+                mBorderPaint.setStyle(Paint.Style.STROKE);
+                mBorderPaint.setColor(mSelectedRectStrokeColor);
+                mBorderPaint.setAlpha(255);
+                canvas.drawRect(mBorderRect, mBorderPaint);
+            }
         }
 
         // draw minimum thumb (& shadow if requested) if not a single thumb control

--- a/rangeseekbar/src/main/java/org/florescu/android/rangeseekbar/RangeSeekBar.java
+++ b/rangeseekbar/src/main/java/org/florescu/android/rangeseekbar/RangeSeekBar.java
@@ -24,6 +24,8 @@ Agile Sports Technologies, Inc. Modifications:
 - Expose which handle was last touched in on change listener
 - Add configuration to display icon to left of left thumb
 - Allowing selected rectangle stroke to be switched on/off
+- Ability to show/hide thumbs
+- Can supply different selected rect color and opacity when control is disabled
 */
 
 package org.florescu.android.rangeseekbar;
@@ -155,7 +157,9 @@ public class RangeSeekBar<T extends Number> extends ImageView {
     private int mActiveColor;
     private int mDefaultColor;
     private int mSelectedRectColor;
+    private int mSelectedRectDisabledColor;
     private int mSelectedRectAlpha;
+    private int mSelectedRectDisabledAlpha;
     private int mSelectedRectStrokeColor;
     private int mTextAboveThumbsColor;
     private int mSelectedRectStrokeOffsetDp;
@@ -170,6 +174,7 @@ public class RangeSeekBar<T extends Number> extends ImageView {
     private Matrix mThumbShadowMatrix = new Matrix();
 
     private boolean mActivateOnDefaultValues;
+    private boolean mThumbsAllowed = true;
 
     // Use drawable and not bitmap so we can handle vector drawables
     private Drawable mIconOnBarDrawable;
@@ -247,7 +252,9 @@ public class RangeSeekBar<T extends Number> extends ImageView {
                 mActiveColor = a.getColor(R.styleable.RangeSeekBar_activeColor, ACTIVE_COLOR);
                 mDefaultColor = a.getColor(R.styleable.RangeSeekBar_defaultColor, Color.GRAY);
                 mSelectedRectColor = a.getColor(R.styleable.RangeSeekBar_selectedRectColor, Color.parseColor("#4D4D4D"));
+                mSelectedRectDisabledColor = a.getColor(R.styleable.RangeSeekBar_selectedRectDisabledColor, mSelectedRectColor);
                 mSelectedRectAlpha = a.getInt(R.styleable.RangeSeekBar_selectedRectAlpha, DEFAULT_SELECTED_RECT_ALPHA);
+                mSelectedRectDisabledAlpha = a.getInt(R.styleable.RangeSeekBar_selectedRectDisabledAlpha, mSelectedRectAlpha);
                 mSelectedRectStrokeColor = a.getColor(R.styleable.RangeSeekBar_selectedRectStrokeColor, Color.WHITE);
                 mShowSelectedRectStroke = a.getBoolean(R.styleable.RangeSeekBar_showSelectedRectStroke, true);
                 mSelectedRectStrokeOffsetDp = mShowSelectedRectStroke ? SELECTED_RECT_STROKE_WIDTH_IN_DP/2 : 0;
@@ -376,6 +383,11 @@ public class RangeSeekBar<T extends Number> extends ImageView {
                     mThumbHalfHeight,
                     Path.Direction.CW);
         }
+    }
+
+    public void setShowThumbs(boolean showThumbs) {
+        mThumbsAllowed = showThumbs;
+        invalidate();
     }
 
     public void setProgressValue(T value) {
@@ -775,8 +787,8 @@ public class RangeSeekBar<T extends Number> extends ImageView {
             mBorderRect.right = normalizedToScreen(normalizedMaxValue) - mThumbHalfWidth;
 
             mBorderPaint.setStyle(Paint.Style.FILL);
-            mBorderPaint.setColor(mSelectedRectColor);
-            mBorderPaint.setAlpha(mSelectedRectAlpha);
+            mBorderPaint.setColor(isEnabled() ? mSelectedRectColor : mSelectedRectDisabledColor);
+            mBorderPaint.setAlpha(isEnabled() ? mSelectedRectAlpha : mSelectedRectDisabledAlpha);
             canvas.drawRect(mBorderRect, mBorderPaint);
 
             if (mShowSelectedRectStroke) {
@@ -890,6 +902,10 @@ public class RangeSeekBar<T extends Number> extends ImageView {
                            Bitmap disabledThumbImage,
                            Bitmap thumbPressedImage,
                            Bitmap thumbImage) {
+        if (!mThumbsAllowed) {
+            return;
+        }
+
         Bitmap buttonToDraw;
         if (!mActivateOnDefaultValues && areSelectedValuesDefault) {
             buttonToDraw = disabledThumbImage;
@@ -909,6 +925,10 @@ public class RangeSeekBar<T extends Number> extends ImageView {
      * @param canvas      the canvas on which to draw the shadow
      */
     private void drawThumbShadow(float screenCoord, Canvas canvas) {
+        if (!mThumbsAllowed) {
+            return;
+        }
+
         mThumbShadowMatrix.setTranslate(screenCoord + mThumbShadowXOffset, mTextOffset + mThumbHalfHeight + mThumbShadowYOffset);
         mTranslatedThumbShadowPath.set(mThumbShadowPath);
         mTranslatedThumbShadowPath.transform(mThumbShadowMatrix);

--- a/rangeseekbar/src/main/res/values/attrs.xml
+++ b/rangeseekbar/src/main/res/values/attrs.xml
@@ -14,6 +14,9 @@
         <!-- show a rectangle border around the selected area (the area in between the range labels) -->
         <attr name="showSelectedRect" format="boolean"/>
 
+        <!-- Toggles the border around the selected rect on/off -->
+        <attr name="showSelectedRectStroke" format="boolean"/>
+
         <!-- show the labels on the right and left-->
         <attr name="showLabels" format="boolean"/>
 

--- a/rangeseekbar/src/main/res/values/attrs.xml
+++ b/rangeseekbar/src/main/res/values/attrs.xml
@@ -45,6 +45,10 @@
         <attr name="selectedRectColor" format="color"/>
         <attr name="selectedRectAlpha" format="integer"/>
 
+        <!-- the color and opacity of the selected rect (if control is disabled) -->
+        <attr name="selectedRectDisabledColor" format="color"/>
+        <attr name="selectedRectDisabledAlpha" format="integer"/>
+
         <!-- the stroke color of the selected rect (if visible) -->
         <attr name="selectedRectStrokeColor" format="color"/>
 


### PR DESCRIPTION
Can now have a selected rect with no stroke...

![select-rect-no-stroke](https://cloud.githubusercontent.com/assets/5814579/15894736/7030d1c6-2d7f-11e6-9f8b-5c9f03b558de.png)

Can now show/hide the seek bar thumbs and supply a different color/opacity when the control is disabled...

![selected-rect-enabled](https://cloud.githubusercontent.com/assets/5814579/15894737/703214f0-2d7f-11e6-8c38-c75e71ef80da.png)

![selected-rect-disabled](https://cloud.githubusercontent.com/assets/5814579/15894735/7030d162-2d7f-11e6-891a-ba9522c0161b.png)
