### PR TITLE
Provide option to allow icon and thumb to overlap

### DIFF
--- a/rangeseekbar-sample/src/main/java/org/florescu/android/rangeseekbar/sample/DemoActivity.java
+++ b/rangeseekbar-sample/src/main/java/org/florescu/android/rangeseekbar/sample/DemoActivity.java
@@ -60,7 +60,7 @@ public class DemoActivity extends Activity {
         // Seek bar for which we will set icon on bar and its color in code
         RangeSeekBar rangeSeekBarIconOnBarWithCode = (RangeSeekBar) findViewById(R.id.rangeSeekBarIconOnBarWithCode);
         Drawable iconOnBarDrawable = ContextCompat.getDrawable(this, android.R.drawable.ic_lock_idle_alarm);
-        rangeSeekBarIconOnBarWithCode.setIconOnBar(iconOnBarDrawable, Color.WHITE);
+        rangeSeekBarIconOnBarWithCode.setIconOnBar(iconOnBarDrawable, Color.WHITE, true);
     }
 
     public void toggleSeekBarEnabled(View v) {

--- a/rangeseekbar/src/main/res/values/attrs.xml
+++ b/rangeseekbar/src/main/res/values/attrs.xml
@@ -85,6 +85,9 @@
         <!-- the color of the icon on the bar -->
         <attr name="iconOnBarColor" format="color"/>
 
+        <!-- whether icon should be drawn on the bar if it will overlap thumb -->
+        <attr name="iconOnBarCanOverlapThumb" format="boolean"/>
+
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
- Add new option iconOnBarOverlapThumb that specifies whether icon on bar should be drawn if it will overlap thumb
- If drawing icon when it may overlap thumb, make sure it fits in space between thumbs and is centered
- 2nd seek bar with an icon in sample app now allows icon to be drawn over thumbs
