### PR TITLE
moving bar icon up slightly when selected rect stroke is disabled

### DIFF
--- a/rangeseekbar/src/main/java/org/florescu/android/rangeseekbar/RangeSeekBar.java
+++ b/rangeseekbar/src/main/java/org/florescu/android/rangeseekbar/RangeSeekBar.java
@@ -952,7 +952,7 @@ public class RangeSeekBar<T extends Number> extends ImageView {
 
         final int iconTopMarginPx = dpToPx(ICON_ON_BAR_TOP_MARGIN_IN_DP) - (mShowSelectedRectStroke
                 ? 0
-                : dpToPx(SELECTED_RECT_STROKE_WIDTH_IN_DP/2));
+                : dpToPx(SELECTED_RECT_STROKE_WIDTH_IN_DP));
         final int iconLeftMarginPx = dpToPx(ICON_ON_BAR_LEFT_MARGIN_IN_DP);
         boolean drawIcon = false;
         int sidePx = dpToPx(ICON_ON_BAR_SIDE_IN_DP);


### PR DESCRIPTION
When the stroke was disabled on the selected rect the bar icon would no longer be spaced correctly so this PR fixes that issue.
