### PR TITLE
Selected Rect over Thumbs

### DIFF
--- a/rangeseekbar-sample/src/main/res/layout/main.xml
+++ b/rangeseekbar-sample/src/main/res/layout/main.xml
@@ -239,6 +239,7 @@
             rsb:valuesAboveThumbs="false"
             rsb:showSelectedRect="true"
             rsb:allowSelectedRectDrag="true"
+            rsb:showSelectedRectStroke="false"
             />
 
         <TextView
@@ -305,6 +306,31 @@
             rsb:selectedRectDisabledColor="@color/primary_material_light"
             rsb:selectedRectDisabledAlpha="255"
             />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="8dp"
+            android:text="range seek bar with selected rect over thumbs"
+            />
+
+        <org.florescu.android.rangeseekbar.RangeSeekBar
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            rsb:activeColor="@android:color/holo_orange_dark"
+            rsb:selectedRectColor="@android:color/holo_blue_light"
+            rsb:selectedRectAlpha="200"
+            rsb:barHeight="2dp"
+            rsb:showLabels="false"
+            rsb:valuesAboveThumbs="false"
+            rsb:showSelectedRect="true"
+            rsb:showSelectedRectOverThumbs="true"
+            rsb:allowSelectedRectDrag="true"
+            rsb:showSelectedRectStroke="false"
+            rsb:selectedRectDisabledColor="@color/primary_material_light"
+            rsb:selectedRectDisabledAlpha="255"
+            />
+
 
     </LinearLayout>
 

--- a/rangeseekbar/src/main/java/org/florescu/android/rangeseekbar/RangeSeekBar.java
+++ b/rangeseekbar/src/main/java/org/florescu/android/rangeseekbar/RangeSeekBar.java
@@ -26,6 +26,7 @@ Agile Sports Technologies, Inc. Modifications:
 - Allowing selected rectangle stroke to be switched on/off
 - Ability to show/hide thumbs
 - Can supply different selected rect color and opacity when control is disabled
+- Can choose if selected rect sits in between the left and right thumb or over them
 */
 
 package org.florescu.android.rangeseekbar;
@@ -148,6 +149,7 @@ public class RangeSeekBar<T extends Number> extends ImageView {
     private boolean mSingleThumb;
     private boolean mAlwaysActive;
     private boolean mShowSelectedBorder;
+    private boolean mShowSelectedRectOverThumbs;
     private boolean mShowSelectedRectStroke;
     private boolean mShowLabels;
     private boolean mShowTextAboveThumbs;
@@ -247,6 +249,7 @@ public class RangeSeekBar<T extends Number> extends ImageView {
                 mTextAboveThumbsColor = a.getColor(R.styleable.RangeSeekBar_textAboveThumbsColor, Color.WHITE);
                 mSingleThumb = a.getBoolean(R.styleable.RangeSeekBar_singleThumb, false);
                 mShowSelectedBorder = a.getBoolean(R.styleable.RangeSeekBar_showSelectedRect, false);
+                mShowSelectedRectOverThumbs = a.getBoolean(R.styleable.RangeSeekBar_showSelectedRectOverThumbs, false);
                 mShowLabels = a.getBoolean(R.styleable.RangeSeekBar_showLabels, true);
                 mInternalPad = a.getDimensionPixelSize(R.styleable.RangeSeekBar_internalPadding, INITIAL_PADDING_IN_DP);
                 barHeight = a.getDimensionPixelSize(R.styleable.RangeSeekBar_barHeight, LINE_HEIGHT_IN_DP);
@@ -788,8 +791,8 @@ public class RangeSeekBar<T extends Number> extends ImageView {
 
         // Border around thumbs
         if (mShowSelectedBorder) {
-            mBorderRect.left = mRect.left + mThumbHalfWidth;
-            mBorderRect.right = normalizedToScreen(normalizedMaxValue) - mThumbHalfWidth;
+            mBorderRect.left = mRect.left + (mShowSelectedRectOverThumbs ? 0 : mThumbHalfWidth);
+            mBorderRect.right = normalizedToScreen(normalizedMaxValue) - (mShowSelectedRectOverThumbs ? 0 : mThumbHalfWidth);
 
             mBorderPaint.setStyle(Paint.Style.FILL);
             mBorderPaint.setColor(isEnabled() ? mSelectedRectColor : mSelectedRectDisabledColor);

--- a/rangeseekbar/src/main/res/values/attrs.xml
+++ b/rangeseekbar/src/main/res/values/attrs.xml
@@ -14,6 +14,9 @@
         <!-- show a rectangle border around the selected area (the area in between the range labels) -->
         <attr name="showSelectedRect" format="boolean"/>
 
+        <!-- show a rectangle border around the selected area including the mid-way point in each thumb -->
+        <attr name="showSelectedRectOverThumbs" format="boolean"/>
+
         <!-- Toggles the border around the selected rect on/off -->
         <attr name="showSelectedRectStroke" format="boolean"/>
 


### PR DESCRIPTION
The selected rect can now sit over the Seek Bar thumbs using the `showSelectedRectOverThumbs` property.

![screen shot 2016-07-04 at 11 04 17](https://cloud.githubusercontent.com/assets/5814579/16557341/16709542-41d7-11e6-9775-6e4f879e3022.png)
