### PR TITLE
Allow total height of bar to be configured/changed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Mon Jun 05 16:29:51 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/rangeseekbar-sample/build.gradle
+++ b/rangeseekbar-sample/build.gradle
@@ -7,7 +7,7 @@ repositories {
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "20.0.0"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "org.florescu.android.rangeseekbar.sample"

--- a/rangeseekbar-sample/src/main/java/org/florescu/android/rangeseekbar/sample/DemoActivity.java
+++ b/rangeseekbar-sample/src/main/java/org/florescu/android/rangeseekbar/sample/DemoActivity.java
@@ -34,6 +34,10 @@ import org.florescu.android.rangeseekbar.RangeSeekBar;
 
 public class DemoActivity extends Activity {
 
+    private static final int SEEK_BAR_NEW_DEFAULT_HEIGHT = 60;
+
+    private int mInitialDefaultHeight;
+
     /**
      * Called when the activity is first created.
      */
@@ -64,11 +68,31 @@ public class DemoActivity extends Activity {
 
         RangeSeekBar rangeSeekBarOffsetIcon = (RangeSeekBar) findViewById(R.id.rangeSeekBarOffsetIcon);
         rangeSeekBarOffsetIcon.setIconOnBar(iconOnBarDrawable, Color.WHITE, true);
+
+        // Disabled seek bar with a changeable height
+        RangeSeekBar rangeSeekBarChangeHeight = (RangeSeekBar) findViewById(R.id.rangeSeekBarChangeHeight);
+        rangeSeekBarChangeHeight.setEnabled(false);
+        rangeSeekBarChangeHeight.setShowThumbs(false);
+        mInitialDefaultHeight = rangeSeekBarChangeHeight.getDefaultHeight();
     }
 
     public void toggleSeekBarEnabled(View v) {
         RangeSeekBar rangeSeekBarNoThumbs = (RangeSeekBar) findViewById(R.id.rangeSeekBarNoThumbs);
         rangeSeekBarNoThumbs.setEnabled(!rangeSeekBarNoThumbs.isEnabled());
         rangeSeekBarNoThumbs.setShowThumbs(rangeSeekBarNoThumbs.isEnabled());
+    }
+
+    public void changeSeekBarHeight(View v) {
+        RangeSeekBar rangeSeekBarChangeableHeight =
+                (RangeSeekBar) findViewById(R.id.rangeSeekBarChangeHeight);
+
+        int iconOnBarSide = rangeSeekBarChangeableHeight.getDefaultHeight();
+        if (iconOnBarSide == mInitialDefaultHeight) {
+            rangeSeekBarChangeableHeight.setDefaultHeight(SEEK_BAR_NEW_DEFAULT_HEIGHT);
+        } else {
+            rangeSeekBarChangeableHeight.setDefaultHeight(mInitialDefaultHeight);
+        }
+
+        rangeSeekBarChangeableHeight.invalidate();
     }
 }

--- a/rangeseekbar-sample/src/main/res/layout/main.xml
+++ b/rangeseekbar-sample/src/main/res/layout/main.xml
@@ -274,7 +274,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="8dp"
-            android:text="range seek bar with selected rect that has thumb handles hidden and rect color changed when you toggle the control enabled/disabled"
+            android:text="Range seek bar with selected rect that has thumb handles hidden and rect color changed when you toggle the control enabled/disabled"
             />
 
         <Button
@@ -311,7 +311,39 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="8dp"
-            android:text="range seek bar with selected rect over thumbs"
+            android:text="Disabled range seek bar with changeable height"
+            />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="changeSeekBarHeight"
+            android:text="Change Height"/>
+
+        <org.florescu.android.rangeseekbar.RangeSeekBar
+            android:id="@+id/rangeSeekBarChangeHeight"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            rsb:showSelectedRect="true"
+            rsb:showSelectedRectOverThumbs="true"
+            rsb:selectedRectColor="#4e5d6c"
+            rsb:showSelectedRectStroke="false"
+            rsb:showLabels="false"
+            rsb:valuesAboveThumbs="false"
+            rsb:iconOnBarLeftMargin="2dp"
+            rsb:iconOnBarTopMargin="8dp"
+            rsb:iconOnBarSide="14dp"
+            rsb:iconOnBar="@mipmap/ic_launcher"
+            rsb:iconOnBarColor="@android:color/white"
+            rsb:internalPadding="5dp"
+            rsb:barHeight="0dp"
+            rsb:defaultHeight="48dp"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="8dp"
+            android:text="Range seek bar with selected rect over thumbs"
             />
 
         <org.florescu.android.rangeseekbar.RangeSeekBar
@@ -332,7 +364,6 @@
             rsb:selectedRectDisabledAlpha="255"
             rsb:iconOnBarLeftMargin="5dp"
             />
-
 
     </LinearLayout>
 

--- a/rangeseekbar/build.gradle
+++ b/rangeseekbar/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.1'
     }
 }
 
@@ -12,7 +12,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "20.0.0"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 15

--- a/rangeseekbar/src/main/res/values/attrs.xml
+++ b/rangeseekbar/src/main/res/values/attrs.xml
@@ -95,6 +95,13 @@
         <attr name="iconOnBarLeftMargin" format="dimension"/>
         <attr name="iconOnBarTopMargin" format="dimension"/>
 
+        <!-- Width and height of (square) icon on bar -->
+        <attr name="iconOnBarSide" format="dimension"/>
+
+        <!-- Default height of bar (when thumbs are not allowed and therefore their height do not
+             factor in, for example) -->
+        <attr name="defaultHeight" format="dimension"/>
+
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
* Add default height value that specifies total height of seekbar when
  thumb height should not be used (i.e., when thumbs are not allowed).
  Value can be specified in rsc files via new defaultHeight attr. If
  not specified, fallsback to height of any icon plus icon margins.
* Allow total height of seekbar to be changed programmatically
* Switch to default height if thumbs are not allowed
* In sample app, add seekbar whose height can be changed via a button
* Update gradle/tools