### PR TITLE
Downgrade gradle from 2.3.1 to 2.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
https://repo1.maven.org/maven2/com/android/tools/build/gradle/, which
jitpack uses to resolve dependencies does not yet have gradle 2.3.1.
Therefore, we downgrade to 2.3.0 so jitpack build will succeed.