### PR TITLE
Downgrade gradle to 2.3.0 in rangeseekbar module

### DIFF
--- a/rangeseekbar/build.gradle
+++ b/rangeseekbar/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 


### PR DESCRIPTION
https://repo1.maven.org/maven2/com/android/tools/build/gradle/, which
jitpack uses to resolve dependencies does not yet have gradle 2.3.1.
Therefore, we downgrade to 2.3.0 so jitpack build will succeed.